### PR TITLE
Several project setup fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+/start text eol=lf

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Some key notes about this design are as follows:
  git clone git@github.com:twitterdev/sample-python-connector.git sample-python-connector
  cd sample-python-connector
  sh script/bootstrap.sh
- sh ./start.sh
+ pip install -r requirements.txt
+ sh ./start
  ```
 
  To run with Vagrant:
@@ -33,7 +34,8 @@ Some key notes about this design are as follows:
  vagrant init
  vagrant ssh
  cd /vagrant
- sh ./start.sh
+ pip install -r requirements.txt
+ sh ./start
  ```
 
 ##Whats Next?

--- a/bin/sample_python_app.py
+++ b/bin/sample_python_app.py
@@ -194,7 +194,7 @@ def config_file_path():
 
 
 def write_out_config(config):
-    with open(config_file_path(), 'r+') as config_file:
+    with open(config_file_path(), 'w+') as config_file:
         config_file.truncate()
         config.write(config_file)
 

--- a/config/gnip.cfg.example
+++ b/config/gnip.cfg.example
@@ -3,7 +3,7 @@ username=<un>
 password=<pwd>
 
 [sys]
-logfilepath=../log
+logfilepath=log
 
 [stream]
 # Twitter Powertrack stream (Gnip 2.5)

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 export DEBIAN_FRONTEND=noninteractive
-sudo apt-get update
+sudo apt-get update -y
 sudo apt-get install -yq git redis-server libpython-dev tmux silversearcher-ag build-essential autoconf libtool pkg-config idle-python2.7
 
 # Mongo
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
-sudo apt-get update
-sudo apt-get install mongodb-org
+sudo apt-get update -y
+sudo apt-get install mongodb-org -y
 
 sudo apt-get install -y curl
 sudo curl https://bootstrap.pypa.io/get-pip.py > pip_install.py

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -9,10 +9,11 @@ echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | 
 sudo apt-get update
 sudo apt-get install mongodb-org
 
+sudo apt-get install -y curl
 sudo curl https://bootstrap.pypa.io/get-pip.py > pip_install.py
 sudo python pip_install.py
 rm pip_install.py
 
-sudo apt-get install -y zsh curl
+sudo apt-get install -y zsh
 chsh -s $(which zsh)
 sudo rm -rf ~/.oh-my-zsh && sudo curl -L http://install.ohmyz.sh > ~/install_zsh.sh && sudo zsh ~/install_zsh.sh


### PR DESCRIPTION
I ran into several issues getting this to run, so here's what I had to fix:
- the shell scripts should be forced to LF. I ran this in Vagrant on Windows, so the CRLF endings from my Windows git clone made the script un-runnable in Ubuntu.
- the README needs to mention installing the python requirements
- the README refers to `start.sh` which at some point must have been renamed to just `start`
- `sample_python_app.py` tries to save a config file but was using read mode instead of write
- the relative path to the log directory is outside the project folder. In Vagrant, for example, this becomes the absolute path `/log`, which isn't writable.
- the `bootstrap.sh` file should use the `-y` flag when running apt-get. It should also install curl _before_ using curl to install pip.

I wasn't able to actually test whether the program streams data from Gnip correctly because I found out my access doesn't include the streaming APIs, but it at least ran after these changes.
